### PR TITLE
Add check for undefined offset for bandwith of a domain.

### DIFF
--- a/src/DirectAdmin/Objects/Domain.php
+++ b/src/DirectAdmin/Objects/Domain.php
@@ -347,7 +347,7 @@ class Domain extends BaseObject
         // Parse plain options
         $bandwidths = array_map('trim', explode('/', $config['bandwidth']));
         $this->bandwidthUsed = floatval($bandwidths[0]);
-        $this->bandwidthLimit = ctype_alpha($bandwidths[1]) ? null : floatval($bandwidths[1]);
+        $this->bandwidthLimit = !isset($bandwidths[1]) || ctype_alpha($bandwidths[1]) ? null : floatval($bandwidths[1]);
         $this->diskUsage = floatval($config['quota']);
 
         $this->aliases = array_filter(explode('|', $config['alias_pointers']));


### PR DESCRIPTION
If the domain bandwidth limit is set to shared, you don't receive $bandwidths[1]